### PR TITLE
Hide download report when url is undefined

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -297,6 +297,7 @@
                   :href="props.item.download"
                   target="_blank"
                   :class="{ 'lg-and-up': !$vuetify.breakpoint.lgAndUp }"
+                  v-if="props.item.download"
                 >
                   <template v-if="$vuetify.breakpoint.lgAndUp">
                     <v-icon size="19" class="notranslate">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Cloud download was shown even if there are no reports links
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
